### PR TITLE
Python 3 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,8 @@ PyBabel-JSON
 
 Release notes
 --------------
-- 0.1.0 - Initial release
+- 0.2.0 - Added Python 3 support.
+- 0.1.0 - Initial release.
 
 Installation
 --------------

--- a/pybabel_json/extractor.py
+++ b/pybabel_json/extractor.py
@@ -54,7 +54,7 @@ class JsonExtractor(object):
             line_number=token.lineno,
             content=value
         )
-        for key,value in self.token_params.iteritems():
+        for key,value in self.token_params.items():
             if key == 'alt_token':
                 result['alt_content']=unquote_string(value.value)
                 result['alt_line_number']=value.lineno

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,25 @@ def read(fname):
 
 setup(
     name='PyBabel-json',
-    version='0.1.0',
+    version='0.2.0',
     description='PyBabel json gettext strings extractor',
     author='Anton Bykov aka Tigra San',
     author_email='tigrawap@gmail.com',
     long_description=read('README.rst'),
     packages=['pybabel_json'],
     url="https://github.com/tigrawap/pybabel-json",
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
     install_requires=[
         'babel',
     ],

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -11,8 +11,12 @@ class TestExtraction(unittest.TestCase):
 
     def setUp(self):
         stderr = None if 'PYBABEL_JSON_DEBUG' in os.environ else PIPE
-        self.found_transes = Popen(['pybabel','extract','-F','babel.cfg','-o','messages.pot','.'],stdout=PIPE,stderr=stderr).stdout.read()
-        with open(os.path.join(os.path.dirname(__file__),'messages.pot'),'r') as output:
+        dirname = os.path.dirname(__file__)
+        cfg = 'babel.cfg'
+        pot_file = 'messages.pot'
+
+        self.found_transes = Popen(['pybabel','extract','-F',cfg,'-o',pot_file,'.'],stdout=PIPE,stderr=stderr).stdout.read()
+        with open(pot_file, 'r') as output:
             self.output = output.read()
 
     def test_number_of_occurences(self):


### PR DESCRIPTION
Added support for Python 3, tested with 3.4.3 on osx 10.7.5 only. Also added classifiers to let others know and bumped the version.

refs #2 
